### PR TITLE
feat: add persisted theme preference

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Geist, Geist_Mono } from 'next/font/google';
 import './globals.css';
 import { Toaster } from '@/components/ui/sonner';
 import { UserPreferencesProvider } from '@/lib/contexts/UserPreferencesContext';
+import { ThemeProvider } from 'next-themes';
 
 const geistSans = Geist({
   variable: '--font-geist-sans',
@@ -25,11 +26,13 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        <UserPreferencesProvider>{children}</UserPreferencesProvider>
+        <ThemeProvider attribute="class" defaultTheme="light">
+          <UserPreferencesProvider>{children}</UserPreferencesProvider>
+        </ThemeProvider>
         <Toaster position="top-center" richColors />
       </body>
     </html>

--- a/src/components/layout/nav-shell.tsx
+++ b/src/components/layout/nav-shell.tsx
@@ -35,6 +35,7 @@ import {
 } from 'lucide-react';
 import { toast } from 'sonner';
 import { UnitToggle } from '@/components/ui/unit-toggle';
+import { ThemeToggle } from '@/components/ui/theme-toggle';
 
 interface NavItem {
   href: string;
@@ -112,6 +113,7 @@ export function NavShell({ children, user }: NavShellProps) {
 
         <div className="flex items-center space-x-2">
           <UnitToggle />
+          <ThemeToggle />
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
               <Button variant="ghost" size="icon" className="rounded-full">
@@ -190,6 +192,10 @@ export function NavShell({ children, user }: NavShellProps) {
               <div className="flex items-center justify-between px-2">
                 <span className="text-sm">Weight Unit</span>
                 <UnitToggle />
+              </div>
+              <div className="flex items-center justify-between px-2">
+                <span className="text-sm">Theme</span>
+                <ThemeToggle />
               </div>
               <Button
                 variant="outline"

--- a/src/components/ui/theme-toggle.tsx
+++ b/src/components/ui/theme-toggle.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import { Moon, Sun } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { toast } from 'sonner';
+import {
+  useUserPreferences,
+  Theme,
+} from '@/lib/contexts/UserPreferencesContext';
+
+export function ThemeToggle() {
+  const { theme, updateTheme, loading } = useUserPreferences();
+
+  const handleToggle = async () => {
+    const newTheme: Theme = theme === 'dark' ? 'light' : 'dark';
+
+    try {
+      await updateTheme(newTheme);
+      toast.success(`Theme changed to ${newTheme}`);
+    } catch (error) {
+      toast.error('Failed to update theme');
+      console.error('Error updating theme:', error);
+    }
+  };
+
+  const icon =
+    theme === 'dark' ? (
+      <Moon className="h-4 w-4" />
+    ) : (
+      <Sun className="h-4 w-4" />
+    );
+
+  if (loading) {
+    return (
+      <Button variant="outline" size="icon" disabled>
+        {icon}
+      </Button>
+    );
+  }
+
+  return (
+    <Button variant="outline" size="icon" onClick={handleToggle}>
+      {icon}
+    </Button>
+  );
+}

--- a/src/lib/types/database.ts
+++ b/src/lib/types/database.ts
@@ -7,6 +7,7 @@ export interface Database {
           id: string;
           user_id: string;
           weight_unit: 'kg' | 'lbs';
+          theme: 'light' | 'dark';
           created_at: string;
           updated_at: string;
         };
@@ -14,6 +15,7 @@ export interface Database {
           id?: string;
           user_id: string;
           weight_unit?: 'kg' | 'lbs';
+          theme?: 'light' | 'dark';
           created_at?: string;
           updated_at?: string;
         };
@@ -21,6 +23,7 @@ export interface Database {
           id?: string;
           user_id?: string;
           weight_unit?: 'kg' | 'lbs';
+          theme?: 'light' | 'dark';
           created_at?: string;
           updated_at?: string;
         };

--- a/supabase/migrations/20250530155511_add_theme_preference.sql
+++ b/supabase/migrations/20250530155511_add_theme_preference.sql
@@ -1,0 +1,3 @@
+-- Add theme preference to user_preferences
+ALTER TABLE user_preferences
+ADD COLUMN theme TEXT NOT NULL DEFAULT 'light';


### PR DESCRIPTION
## Summary
- add global theme toggle with next-themes
- store the theme in `user_preferences`
- expose theme controls in NavShell
- wrap app in ThemeProvider
- add migration and types for theme preference

## Testing
- `pnpm lint`
- `pnpm test` *(fails: No test files found)*