### PR TITLE
Add utility tests

### DIFF
--- a/src/lib/__tests__/1rm-calculator.test.ts
+++ b/src/lib/__tests__/1rm-calculator.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import {
+  calculate1RM,
+  calculateAverage1RM,
+  calculatePercentage1RM,
+  estimateRepsAt1RMPercentage,
+  epleyFormula,
+  brzyckiFormula,
+  lombardiFormula,
+  oconnerFormula,
+  mayhewFormula,
+} from '../utils/1rm-calculator';
+
+describe('1RM calculator formulas', () => {
+  it('computes 1RM using each formula', () => {
+    const weight = 100;
+    const reps = 5;
+    expect(calculate1RM(weight, reps, epleyFormula)).toBe(117);
+    expect(calculate1RM(weight, reps, brzyckiFormula)).toBe(113);
+    expect(calculate1RM(weight, reps, lombardiFormula)).toBe(117);
+    expect(calculate1RM(weight, reps, oconnerFormula)).toBe(113);
+    expect(calculate1RM(weight, reps, mayhewFormula)).toBe(119);
+  });
+
+  it('returns 0 for non positive input', () => {
+    expect(calculate1RM(0, 5)).toBe(0);
+    expect(calculate1RM(100, 0)).toBe(0);
+  });
+
+  it('calculates average across formulas', () => {
+    const avg = calculateAverage1RM(100, 5);
+    expect(avg).toBe(116);
+  });
+
+  it('calculates percentage of 1RM', () => {
+    expect(calculatePercentage1RM(200, 80)).toBe(160);
+  });
+
+  it('estimates reps at given percentage', () => {
+    expect(estimateRepsAt1RMPercentage(80)).toBe(8);
+    expect(estimateRepsAt1RMPercentage(100)).toBe(1);
+    expect(estimateRepsAt1RMPercentage(0)).toBe(0);
+  });
+});

--- a/src/lib/__tests__/date.test.ts
+++ b/src/lib/__tests__/date.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseLocalDate,
+  formatLocalDate,
+  isLocalToday,
+  isLocalTomorrow,
+} from '../utils/date';
+
+describe('date utilities', () => {
+  it('parses YYYY-MM-DD as local date', () => {
+    const date = parseLocalDate('2024-05-10');
+    expect(date.getFullYear()).toBe(2024);
+    expect(date.getMonth()).toBe(4);
+    expect(date.getDate()).toBe(10);
+  });
+
+  it('parses ISO string at start of local day', () => {
+    const date = parseLocalDate('2024-05-10T12:00:00Z');
+    expect(date.getHours()).toBe(0);
+    expect(date.getMinutes()).toBe(0);
+  });
+
+  it('formats date using local timezone', () => {
+    const str = formatLocalDate('2024-05-10', 'yyyy-MM-dd');
+    expect(str).toBe('2024-05-10');
+  });
+
+  it('checks today and tomorrow correctly', () => {
+    const today = new Date();
+    const tomorrow = new Date();
+    tomorrow.setDate(today.getDate() + 1);
+
+    expect(isLocalToday(today)).toBe(true);
+    expect(isLocalTomorrow(tomorrow)).toBe(true);
+  });
+});

--- a/src/lib/__tests__/progression-templates.test.ts
+++ b/src/lib/__tests__/progression-templates.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import {
+  PROGRESSION_TEMPLATES,
+  getTemplatesByGoal,
+  getTemplatesByDifficulty,
+  getTemplatesByType,
+  getTemplateById,
+  scaleTemplate,
+  applyProgressionTemplate,
+} from '../progression-templates';
+
+describe('progression templates helpers', () => {
+  it('filters templates by attributes', () => {
+    expect(getTemplatesByGoal('strength').length).toBe(3);
+    expect(getTemplatesByGoal('powerlifting').length).toBe(1);
+    expect(getTemplatesByDifficulty('intermediate').length).toBe(3);
+    expect(getTemplatesByType('linear').length).toBe(2);
+  });
+
+  it('retrieves template by id', () => {
+    const tpl = getTemplateById('linear-strength');
+    expect(tpl?.name).toBe('Linear Strength Progression');
+  });
+
+  it('scales templates to new duration', () => {
+    const tpl = PROGRESSION_TEMPLATES[0];
+    const scaled = scaleTemplate(tpl, 4);
+    expect(scaled).toHaveLength(4);
+    expect(scaled[0]).toEqual(tpl.weekPattern[0]);
+  });
+
+  it('applies template with overrides', () => {
+    const weeks = applyProgressionTemplate('linear-strength', 3, {
+      weight: 110,
+    });
+    expect(weeks).toHaveLength(3);
+    weeks.forEach((week) => expect(week.weight).toBe(110));
+  });
+});

--- a/src/lib/__tests__/utils.test.ts
+++ b/src/lib/__tests__/utils.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest';
+import { cn } from '../utils';
+
+describe('cn utility', () => {
+  it('merges and deduplicates classes', () => {
+    expect(cn('px-2', 'py-2', 'px-2')).toBe('px-2 py-2');
+  });
+
+  it('handles conditional values', () => {
+    const hidden = false;
+    expect(cn('p-2', hidden && 'hidden', ['text-sm'])).toBe('p-2 text-sm');
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for 1RM calculator formulas
- cover date helpers
- test progression template utilities
- test `cn` helper

## Testing
- `pnpm install --ignore-scripts --frozen-lockfile` *(fails: EHOSTUNREACH)*
- `pnpm lint --fix --max-warnings 0` *(fails: next not found)*
- `pnpm format`
- `pnpm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6839f4979e248323ac15337a4159c298