### PR TITLE
feat: add weekly workout overview

### DIFF
--- a/src/app/logger/page.tsx
+++ b/src/app/logger/page.tsx
@@ -1,10 +1,63 @@
-export default function LoggerPage() {
+import Link from 'next/link';
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+} from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { format } from 'date-fns';
+import { parseLocalDate } from '@/lib/utils/date';
+import { getWorkoutsForCurrentWeek, createFreestyleWorkout } from './actions';
+
+export default async function LoggerPage() {
+  const workouts = await getWorkoutsForCurrentWeek();
+
   return (
-    <div className="container mx-auto px-4 py-8">
-      <h1 className="text-3xl font-bold mb-4">Workout Logger</h1>
-      <p className="text-muted-foreground">
-        Log your workout sets. Coming soon...
-      </p>
+    <div className="container mx-auto px-4 py-8 space-y-8">
+      <div>
+        <h1 className="text-3xl font-bold mb-4">Workout Logger</h1>
+        {workouts.length === 0 ? (
+          <p className="text-muted-foreground">
+            No workouts scheduled for this week.
+          </p>
+        ) : (
+          <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+            {workouts.map((workout) => (
+              <Card key={workout.id}>
+                <CardHeader>
+                  <CardTitle>{workout.label || 'Workout'}</CardTitle>
+                  <CardDescription>
+                    {format(
+                      parseLocalDate(workout.scheduledFor),
+                      'EEEE, MMM d',
+                    )}
+                  </CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <Link href={`/logger/${workout.id}`}>
+                    <Button className="w-full">Start</Button>
+                  </Link>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <div className="space-y-4">
+        <form action={createFreestyleWorkout}>
+          <Button type="submit" className="w-full">
+            Start Freestyle Workout
+          </Button>
+        </form>
+        <Link href="/stats" className="block">
+          <Button variant="outline" className="w-full">
+            View History
+          </Button>
+        </Link>
+      </div>
     </div>
   );
 }

--- a/src/db/queries/workouts.ts
+++ b/src/db/queries/workouts.ts
@@ -1,0 +1,31 @@
+import { db } from '../index';
+import { workouts, mesocycles } from '../schema';
+import { eq, gte, lte, and } from 'drizzle-orm';
+
+export async function getWorkoutsInRange(
+  userId: string,
+  start: Date,
+  end: Date,
+) {
+  const startDate = start.toISOString().split('T')[0];
+  const endDate = end.toISOString().split('T')[0];
+
+  return db
+    .select({
+      id: workouts.id,
+      scheduledFor: workouts.scheduledFor,
+      label: workouts.label,
+      weekNumber: workouts.weekNumber,
+      intensityModifier: workouts.intensityModifier,
+    })
+    .from(workouts)
+    .innerJoin(mesocycles, eq(workouts.mesocycleId, mesocycles.id))
+    .where(
+      and(
+        eq(mesocycles.userId, userId),
+        gte(workouts.scheduledFor, startDate),
+        lte(workouts.scheduledFor, endDate),
+      ),
+    )
+    .orderBy(workouts.scheduledFor);
+}


### PR DESCRIPTION
## Summary
- show current week's workouts on `/logger`
- allow creating a freestyle workout
- add Drizzle query for retrieving workouts

## Testing
- `pnpm lint --fix --max-warnings 0`
- `pnpm format`
- `pnpm exec vitest run`


------
https://chatgpt.com/codex/tasks/task_b_683a052677908323a56b25fd7cb0c3d8