### PR TITLE
feat: add advanced exercise selection

### DIFF
--- a/src/components/catalogue/filter-bar.tsx
+++ b/src/components/catalogue/filter-bar.tsx
@@ -12,6 +12,11 @@ import {
 } from '@/components/ui/select';
 import { Search, Filter, Grid, List, X } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
+import {
+  EQUIPMENT_TYPES,
+  MUSCLE_GROUPS,
+  COMMON_TAGS,
+} from '@/constants/exercises';
 
 interface FilterBarProps {
   onSearchChange: (search: string) => void;
@@ -27,28 +32,9 @@ interface FilterBarProps {
   };
 }
 
-const equipmentTypes = ['barbell', 'dumbbell', 'machine', 'bodyweight'];
-const muscleGroups = [
-  'chest',
-  'back',
-  'shoulders',
-  'biceps',
-  'triceps',
-  'quads',
-  'hamstrings',
-  'glutes',
-  'calves',
-  'traps',
-];
-const commonTags = [
-  'compound',
-  'isolation',
-  'push',
-  'pull',
-  'legs',
-  'arms',
-  'unilateral',
-];
+const equipmentTypes = EQUIPMENT_TYPES;
+const muscleGroups = MUSCLE_GROUPS;
+const commonTags = COMMON_TAGS;
 
 export function FilterBar({
   onSearchChange,

--- a/src/components/logger/exercise-selector.tsx
+++ b/src/components/logger/exercise-selector.tsx
@@ -5,24 +5,46 @@ import { createClient } from '@/lib/supabase/client';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 import { X } from 'lucide-react';
+import {
+  EQUIPMENT_TYPES,
+  MUSCLE_GROUPS,
+  COMMON_TAGS,
+} from '@/constants/exercises';
 
 interface Exercise {
   id: string;
   name: string;
   type: string;
   primary_muscle: string;
+  tags: string[];
 }
 
 interface ExerciseSelectorProps {
-  onSelect: (exerciseId: string, exerciseName?: string) => void;
+  onSelect: (exerciseIds: string[], exerciseNames?: string[]) => void;
   onClose: () => void;
+  multiSelect?: boolean;
 }
 
-export function ExerciseSelector({ onSelect, onClose }: ExerciseSelectorProps) {
+export function ExerciseSelector({
+  onSelect,
+  onClose,
+  multiSelect = false,
+}: ExerciseSelectorProps) {
   const [exercises, setExercises] = useState<Exercise[]>([]);
   const [search, setSearch] = useState('');
   const [loading, setLoading] = useState(true);
+  const [typeFilter, setTypeFilter] = useState<string | null>(null);
+  const [muscleFilter, setMuscleFilter] = useState<string | null>(null);
+  const [tagFilter, setTagFilter] = useState<string | null>(null);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
 
   useEffect(() => {
     fetchExercises();
@@ -46,9 +68,21 @@ export function ExerciseSelector({ onSelect, onClose }: ExerciseSelectorProps) {
     }
   };
 
-  const filtered = exercises.filter((ex) =>
-    ex.name.toLowerCase().includes(search.toLowerCase()),
-  );
+  const filtered = exercises.filter((ex) => {
+    if (search && !ex.name.toLowerCase().includes(search.toLowerCase())) {
+      return false;
+    }
+    if (typeFilter && ex.type !== typeFilter) {
+      return false;
+    }
+    if (muscleFilter && ex.primary_muscle !== muscleFilter) {
+      return false;
+    }
+    if (tagFilter && !ex.tags?.includes(tagFilter)) {
+      return false;
+    }
+    return true;
+  });
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
@@ -66,6 +100,61 @@ export function ExerciseSelector({ onSelect, onClose }: ExerciseSelectorProps) {
             onChange={(e) => setSearch(e.target.value)}
             className="mb-4"
           />
+          <div className="flex flex-wrap gap-2 mb-4">
+            <Select
+              value={typeFilter || 'all'}
+              onValueChange={(v) => setTypeFilter(v === 'all' ? null : v)}
+            >
+              <SelectTrigger className="w-[160px]">
+                <SelectValue placeholder="Equipment" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All Equipment</SelectItem>
+                {EQUIPMENT_TYPES.map((type) => (
+                  <SelectItem key={type} value={type} className="capitalize">
+                    {type}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <Select
+              value={muscleFilter || 'all'}
+              onValueChange={(v) => setMuscleFilter(v === 'all' ? null : v)}
+            >
+              <SelectTrigger className="w-[160px]">
+                <SelectValue placeholder="Muscle" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All Muscles</SelectItem>
+                {MUSCLE_GROUPS.map((muscle) => (
+                  <SelectItem
+                    key={muscle}
+                    value={muscle}
+                    className="capitalize"
+                  >
+                    {muscle}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <Select
+              value={tagFilter || 'all'}
+              onValueChange={(v) => setTagFilter(v === 'all' ? null : v)}
+            >
+              <SelectTrigger className="w-[160px]">
+                <SelectValue placeholder="Tag" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All Tags</SelectItem>
+                {COMMON_TAGS.map((tag) => (
+                  <SelectItem key={tag} value={tag} className="capitalize">
+                    {tag}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
           <div className="max-h-80 overflow-y-auto divide-y">
             {loading ? (
               <div className="text-center py-8 text-muted-foreground">
@@ -81,16 +170,56 @@ export function ExerciseSelector({ onSelect, onClose }: ExerciseSelectorProps) {
                   key={ex.id}
                   variant="ghost"
                   className="w-full flex justify-between items-center py-3 px-2"
-                  onClick={() => onSelect(ex.id, ex.name)}
+                  onClick={() => {
+                    if (multiSelect) {
+                      setSelected((prev) => {
+                        const next = new Set(prev);
+                        if (next.has(ex.id)) {
+                          next.delete(ex.id);
+                        } else {
+                          next.add(ex.id);
+                        }
+                        return next;
+                      });
+                    } else {
+                      onSelect([ex.id], [ex.name]);
+                    }
+                  }}
                 >
-                  <span className="font-medium">{ex.name}</span>
-                  <span className="text-xs text-muted-foreground capitalize">
+                  <span className="font-medium text-left flex-1">
+                    {ex.name}
+                  </span>
+                  <span className="text-xs text-muted-foreground capitalize mr-2">
                     {ex.primary_muscle} • {ex.type}
                   </span>
+                  {multiSelect && (
+                    <input
+                      type="checkbox"
+                      readOnly
+                      className="h-4 w-4"
+                      checked={selected.has(ex.id)}
+                    />
+                  )}
                 </Button>
               ))
             )}
           </div>
+          {multiSelect && (
+            <div className="pt-4 flex justify-end">
+              <Button
+                onClick={() => {
+                  const ids = Array.from(selected);
+                  const names = exercises
+                    .filter((ex) => ids.includes(ex.id))
+                    .map((ex) => ex.name);
+                  onSelect(ids, names);
+                }}
+                disabled={selected.size === 0}
+              >
+                Add Selected
+              </Button>
+            </div>
+          )}
         </CardContent>
       </Card>
     </div>

--- a/src/components/logger/workout-logger.tsx
+++ b/src/components/logger/workout-logger.tsx
@@ -185,43 +185,40 @@ export function WorkoutLogger({ workoutId }: { workoutId: string }) {
     }
   };
 
-  const handleAddExercise = async (
-    exerciseId: string,
-    exerciseName?: string,
-  ) => {
+  const handleAddExercise = async (exerciseIds: string[]) => {
     if (!workout) return;
 
     try {
-      console.log('Adding exercise to workout:', exerciseId, exerciseName);
+      console.log('Adding exercises to workout:', exerciseIds);
       const supabase = createClient();
 
-      // Get the next order index
-      const maxOrderIdx =
+      let orderIdx =
         workout.workout_exercises?.reduce(
           (max, ex) => Math.max(max, ex.order_idx || 0),
           0,
         ) || 0;
 
-      const { error } = await supabase.from('workout_exercises').insert({
-        workout_id: workoutId,
-        exercise_id: exerciseId,
-        order_idx: maxOrderIdx + 1,
-        defaults: {
-          sets: 3,
-          reps: '8-12',
-          rest: '2:00',
-        },
-      });
-
-      if (error) {
-        console.error('Error adding exercise:', error);
-        throw error;
+      for (let i = 0; i < exerciseIds.length; i++) {
+        const { error } = await supabase.from('workout_exercises').insert({
+          workout_id: workoutId,
+          exercise_id: exerciseIds[i],
+          order_idx: ++orderIdx,
+          defaults: {
+            sets: 3,
+            reps: '8-12',
+            rest: '2:00',
+          },
+        });
+        if (error) {
+          console.error('Error adding exercise:', error);
+          throw error;
+        }
       }
 
-      console.log('Added exercise successfully');
-      toast.success('Exercise added!');
+      console.log('Added exercises successfully');
+      toast.success('Exercise(s) added!');
       setIsAddingExercise(false);
-      fetchWorkout(); // Refresh workout data
+      fetchWorkout();
     } catch (err) {
       console.error('Failed to add exercise:', err);
       toast.error('Failed to add exercise');

--- a/src/components/mesocycles/workout-template-designer.tsx
+++ b/src/components/mesocycles/workout-template-designer.tsx
@@ -135,6 +135,15 @@ export function WorkoutTemplateDesigner({
     setShowExerciseSelector(null);
   };
 
+  const addExercisesToTemplate = (
+    templateId: string,
+    exercisesToAdd: Array<{ id: string; name: string }>,
+  ) => {
+    exercisesToAdd.forEach((ex) => {
+      addExerciseToTemplate(templateId, ex.id, ex.name);
+    });
+  };
+
   const updateExercise = (
     templateId: string,
     exerciseIndex: number,
@@ -377,17 +386,13 @@ export function WorkoutTemplateDesigner({
       {/* Exercise Selector Modal */}
       {showExerciseSelector && (
         <ExerciseSelector
-          onSelect={(exerciseId: string, exerciseName?: string) => {
-            console.log(
-              '[WorkoutTemplateDesigner] Exercise selected:',
-              exerciseId,
-              exerciseName,
-            );
-            addExerciseToTemplate(
-              showExerciseSelector,
-              exerciseId,
-              exerciseName || 'Exercise',
-            );
+          multiSelect
+          onSelect={(ids: string[], names?: string[]) => {
+            const selections = ids.map((id, i) => ({
+              id,
+              name: names?.[i] || 'Exercise',
+            }));
+            addExercisesToTemplate(showExerciseSelector, selections);
           }}
           onClose={() => setShowExerciseSelector(null)}
         />

--- a/src/constants/exercises.ts
+++ b/src/constants/exercises.ts
@@ -1,0 +1,22 @@
+export const EQUIPMENT_TYPES = ['barbell', 'dumbbell', 'machine', 'bodyweight'];
+export const MUSCLE_GROUPS = [
+  'chest',
+  'back',
+  'shoulders',
+  'biceps',
+  'triceps',
+  'quads',
+  'hamstrings',
+  'glutes',
+  'calves',
+  'traps',
+];
+export const COMMON_TAGS = [
+  'compound',
+  'isolation',
+  'push',
+  'pull',
+  'legs',
+  'arms',
+  'unilateral',
+];


### PR DESCRIPTION
## Summary
- make equipment/muscle/tag constants reusable
- add advanced filtering and multi-select to `ExerciseSelector`
- wire up multi-select in mesocycle workout designer
- update workout logger to support multi-add

## Testing
- `pnpm lint --fix --max-warnings 0`
- `pnpm format`
- `pnpm exec vitest run`


------
https://chatgpt.com/codex/tasks/task_b_683a12f6a70883239f47ecf49541e2c3