### PR TITLE
fix: remove duplicate strategy selector

### DIFF
--- a/src/components/mesocycles/progressive-intensity-designer.tsx
+++ b/src/components/mesocycles/progressive-intensity-designer.tsx
@@ -312,12 +312,6 @@ export function ProgressiveIntensityDesigner({
 
   return (
     <div className="space-y-6">
-      <ProgressionStrategySelector
-        currentStrategy={progressionStrategy}
-        onStrategyChange={setProgressionStrategy}
-        showDemo={true}
-      />
-
       <Card>
         <CardHeader>
           <CardTitle className="flex items-center justify-between">


### PR DESCRIPTION
## Summary
- remove extra `ProgressionStrategySelector` from the ProgressiveIntensityDesigner

## Testing
- `pnpm lint --fix --max-warnings 0`
- `pnpm format`
- `pnpm test` *(fails to exit; run cancelled)*

------
https://chatgpt.com/codex/tasks/task_b_683e495e9430832396694e9746f5ef36