### PR TITLE
feature/template-strategy-sync

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "format": "prettier --write \"**/*.{js,jsx,ts,tsx,json,css,md}\"",
     "format:check": "prettier --check \"**/*.{js,jsx,ts,tsx,json,css,md}\"",
     "test": "vitest",
+    "test:ci": "vitest run",
     "test:ui": "vitest --ui",
     "test:coverage": "vitest --coverage",
     "e2e": "playwright test",

--- a/src/components/mesocycles/progressive-intensity-designer.tsx
+++ b/src/components/mesocycles/progressive-intensity-designer.tsx
@@ -27,6 +27,7 @@ import {
   PROGRESSION_TEMPLATES,
   applyProgressionTemplate,
 } from '@/lib/progression-templates';
+import { getStrategyForTemplate } from '@/lib/utils/template-strategy-utils';
 import { ProgressionStrategySelector } from './progression-strategy-selector';
 import {
   ProgressionStrategy,
@@ -148,12 +149,12 @@ export function ProgressiveIntensityDesigner({
     }
   }, []); // Empty deps to only run on mount
 
-  // Handle progression type changes (only after initial emission)
+  // Emit changes when progression settings update (after initial emission)
   React.useEffect(() => {
     if (hasEmittedInitial.current) {
       createAndEmitProgressionRef.current(weeklyProgressions);
     }
-  }, [progressionType, weeklyProgressions]);
+  }, [progressionType, progressionStrategy, weeklyProgressions]);
 
   // Current week intensity for the panel
   const currentWeekIntensity = useMemo(() => {
@@ -298,6 +299,8 @@ export function ProgressiveIntensityDesigner({
 
         setWeeklyProgressions(newProgressions);
         setProgressionType(template.type);
+        const strategy = getStrategyForTemplate(template);
+        setProgressionStrategy(strategy);
 
         // Emit changes immediately
         createAndEmitProgressionRef.current(newProgressions, template.type);

--- a/src/lib/__tests__/template-strategy-utils.test.ts
+++ b/src/lib/__tests__/template-strategy-utils.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { PROGRESSION_TEMPLATES } from '../progression-templates';
+import { getStrategyForTemplate } from '../utils/template-strategy-utils';
+import { DEFAULT_STRATEGIES } from '@/types/progression-strategy';
+
+describe('template to strategy mapping', () => {
+  it('maps strength template to strength strategy', () => {
+    const tpl = PROGRESSION_TEMPLATES.find((t) => t.targetGoal === 'strength');
+    if (!tpl) throw new Error('No strength template');
+    const strategy = getStrategyForTemplate(tpl);
+    expect(strategy).toEqual(DEFAULT_STRATEGIES.strength);
+  });
+
+  it('maps hypertrophy template to hypertrophy strategy', () => {
+    const tpl = PROGRESSION_TEMPLATES.find(
+      (t) => t.targetGoal === 'hypertrophy',
+    );
+    if (!tpl) throw new Error('No hypertrophy template');
+    const strategy = getStrategyForTemplate(tpl);
+    expect(strategy).toEqual(DEFAULT_STRATEGIES.hypertrophy);
+  });
+});

--- a/src/lib/utils/template-strategy-utils.ts
+++ b/src/lib/utils/template-strategy-utils.ts
@@ -1,0 +1,22 @@
+import { ProgressionTemplate } from '../progression-templates';
+import {
+  ProgressionStrategy,
+  DEFAULT_STRATEGIES,
+} from '@/types/progression-strategy';
+
+export function getStrategyForTemplate(
+  template: ProgressionTemplate,
+): ProgressionStrategy {
+  switch (template.targetGoal) {
+    case 'strength':
+      return DEFAULT_STRATEGIES.strength;
+    case 'hypertrophy':
+      return DEFAULT_STRATEGIES.hypertrophy;
+    case 'endurance':
+      return DEFAULT_STRATEGIES.conditioning;
+    case 'powerlifting':
+      return DEFAULT_STRATEGIES.peaking;
+    default:
+      return DEFAULT_STRATEGIES.hypertrophy;
+  }
+}


### PR DESCRIPTION
## Summary
- sync progression strategy with selected template in the mesocycle builder
- add util for mapping templates to strategies
- cover new mapping logic with tests
- expose `test:ci` script for CI runs

## Testing
- `pnpm lint --fix --max-warnings 0`
- `pnpm format`
- `pnpm test:ci`


------
https://chatgpt.com/codex/tasks/task_b_683e4d5a0d588323a65cd043bf6ce755