### PR TITLE
fix: adjust dynamic page params type

### DIFF
--- a/src/app/mesocycles/[mesocycleId]/edit/page.tsx
+++ b/src/app/mesocycles/[mesocycleId]/edit/page.tsx
@@ -1,16 +1,18 @@
 import { MesocycleEditWizard } from '@/components/mesocycles/mesocycle-edit-wizard';
 
-export default function EditMesocyclePage({
+export default async function EditMesocyclePage({
   params,
 }: {
-  params: { mesocycleId: string };
+  params: Promise<{ mesocycleId: string }>;
 }) {
+  const { mesocycleId } = await params;
+
   return (
     <div className="container mx-auto px-4 py-8 max-w-2xl">
       <div className="mb-8">
         <h1 className="text-3xl font-bold">Edit Mesocycle</h1>
       </div>
-      <MesocycleEditWizard mesocycleId={params.mesocycleId} />
+      <MesocycleEditWizard mesocycleId={mesocycleId} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- fix dynamic route in mesocycle edit page to use `Promise` params as required by Next.js 15

## Testing
- `pnpm lint --fix --max-warnings 0`
- `pnpm format`
- `pnpm test:ci`


------
https://chatgpt.com/codex/tasks/task_b_683e7be7b9888323be916f87105edb56