### PR TITLE
feat: prefill logger with planned sets

### DIFF
--- a/src/components/logger/SetsList.tsx
+++ b/src/components/logger/SetsList.tsx
@@ -35,8 +35,16 @@ interface SetUpdates {
   partialCount?: number;
 }
 
+interface PlannedSet {
+  setNumber: number;
+  reps: string;
+  rir?: number;
+  rpe?: number;
+}
+
 interface SetsListProps {
   sets: LoggedSet[];
+  plannedSets?: PlannedSet[];
   onSetUpdated?: () => void;
   onSetDeleted?: () => void;
   onUpdateSet?: (setId: string, updates: SetUpdates) => Promise<void>;
@@ -45,6 +53,7 @@ interface SetsListProps {
 
 export function SetsList({
   sets,
+  plannedSets,
   onSetUpdated,
   onSetDeleted,
   onUpdateSet,
@@ -127,6 +136,33 @@ export function SetsList({
     },
     {} as Record<string, LoggedSet[]>,
   );
+
+  if (sets.length === 0 && plannedSets && plannedSets.length > 0) {
+    return (
+      <div className="space-y-2">
+        {plannedSets.map((set) => (
+          <Card key={set.setNumber}>
+            <CardContent className="p-3 flex items-center gap-4">
+              <span className="text-sm font-medium text-muted-foreground">
+                Set {set.setNumber}
+              </span>
+              <span className="font-semibold">{set.reps} reps</span>
+              {typeof set.rir === 'number' && (
+                <span className="text-sm text-muted-foreground">
+                  {set.rir} RIR
+                </span>
+              )}
+              {typeof set.rpe === 'number' && (
+                <span className="text-sm text-muted-foreground">
+                  {set.rpe} RPE
+                </span>
+              )}
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    );
+  }
 
   return (
     <>

--- a/src/components/logger/set-logger.tsx
+++ b/src/components/logger/set-logger.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -36,6 +36,7 @@ interface SetLoggerProps {
     sets?: number;
     reps?: string;
     rir?: number;
+    rpe?: number;
     rest?: string;
   };
   exercise: Exercise;
@@ -51,12 +52,17 @@ export function SetLogger({
   const { weightUnit, convertWeight } = useUserPreferences();
   const [weight, setWeight] = useState<string>('');
   const [reps, setReps] = useState<string>('');
-  const [rir, setRir] = useState<number | undefined>(defaults?.rir);
+  const [rir, setRir] = useState<number | undefined>(
+    defaults?.rir ??
+      (defaults?.rpe !== undefined ? 10 - defaults.rpe : undefined),
+  );
   const [isMyoRep, setIsMyoRep] = useState(false);
   const [myoRepCount, setMyoRepCount] = useState(0);
   const [isPartial, setIsPartial] = useState(false);
   const [partialCount, setPartialCount] = useState(0);
-  const [intensityType, setIntensityType] = useState<'rir' | 'rpe'>('rir');
+  const [intensityType, setIntensityType] = useState<'rir' | 'rpe'>(
+    defaults?.rpe !== undefined ? 'rpe' : 'rir',
+  );
   const [selectedBarbellType, setSelectedBarbellType] = useState<string>('');
 
   // Get the last set's data for quick re-use
@@ -69,6 +75,15 @@ export function SetLogger({
   // Get barbell weights based on user's unit preference
   const barbellWeights =
     weightUnit === 'lbs' ? BARBELL_WEIGHTS_LBS : BARBELL_WEIGHTS;
+
+  useEffect(() => {
+    if (previousSets.length === 0 && defaults?.reps && !reps) {
+      const first = parseInt(defaults.reps.split('-')[0]);
+      if (!isNaN(first)) {
+        setReps(first.toString());
+      }
+    }
+  }, [previousSets.length, defaults, reps]);
 
   console.log('SetLogger Debug:', {
     exerciseName: exercise.name,
@@ -236,7 +251,10 @@ export function SetLogger({
         <CardContent className="pt-6">
           <div className="space-y-4">
             <div className="text-center mb-4">
-              <h3 className="font-semibold">Set {currentSetNumber}</h3>
+              <h3 className="font-semibold">
+                Set {currentSetNumber}
+                {defaults?.sets ? ` of ${defaults.sets}` : ''}
+              </h3>
               {lastSet && (
                 <Button
                   variant="ghost"

--- a/src/components/logger/workout-logger.tsx
+++ b/src/components/logger/workout-logger.tsx
@@ -40,6 +40,7 @@ interface WorkoutExercise {
     sets?: number;
     reps?: string;
     rir?: number;
+    rpe?: number;
     rest?: string;
   };
   exercise: Exercise;
@@ -450,6 +451,17 @@ export function WorkoutLogger({ workoutId }: { workoutId: string }) {
                           (s as LoggedSet & { partial_count?: number })
                             .partial_count ?? 0,
                       }))}
+                    plannedSets={Array.from(
+                      {
+                        length: selectedExercise.defaults?.sets || 0,
+                      },
+                      (_, i) => ({
+                        setNumber: i + 1,
+                        reps: selectedExercise.defaults.reps ?? '',
+                        rir: selectedExercise.defaults.rir,
+                        rpe: selectedExercise.defaults.rpe,
+                      }),
+                    )}
                     onSetUpdated={fetchLoggedSets}
                     onSetDeleted={fetchLoggedSets}
                     onUpdateSet={handleUpdateSet}


### PR DESCRIPTION
## Summary
- prefill logger UI with planned sets and reps
- show number of planned sets in SetLogger
- auto-populate reps input with planned defaults

## Testing
- `pnpm lint --fix --max-warnings 0`
- `pnpm format`
- `pnpm test:ci`
- `pnpm exec tsc --noEmit --strict`
- `pnpm run build` *(fails: Failed to fetch font `Geist`)*

------
https://chatgpt.com/codex/tasks/task_b_683f336cf048832382f64747149d8e26