### PR TITLE
feat: dashboard overview integration

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -16,24 +16,21 @@ import {
   ArrowRight,
 } from 'lucide-react';
 import Link from 'next/link';
+import { createClient } from '@/lib/supabase/server';
+import { redirect } from 'next/navigation';
+import { getDashboardOverview } from '@/db/queries/dashboard';
 
 export default async function DashboardPage() {
-  // TODO: Use supabase to fetch actual data from database
-  // const supabase = await createClient();
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
 
-  // TODO: Fetch actual data from database
-  const stats = {
-    currentWeek: 3,
-    totalWorkouts: 12,
-    nextWorkout: 'Push Day',
-    personalRecords: 2,
-  };
+  if (!user) {
+    redirect('/');
+  }
 
-  const recentWorkouts = [
-    { id: 1, name: 'Push Day', date: '2025-05-25', sets: 24 },
-    { id: 2, name: 'Pull Day', date: '2025-05-23', sets: 22 },
-    { id: 3, name: 'Leg Day', date: '2025-05-21', sets: 20 },
-  ];
+  const overview = await getDashboardOverview(user.id);
 
   return (
     <div className="container mx-auto px-4 py-8">
@@ -69,7 +66,9 @@ export default async function DashboardPage() {
               <Calendar className="h-4 w-4 text-muted-foreground" />
             </CardHeader>
             <CardContent>
-              <div className="text-2xl font-bold">Week {stats.currentWeek}</div>
+              <div className="text-2xl font-bold">
+                Week {overview.currentWeek ?? '-'}
+              </div>
               <p className="text-xs text-muted-foreground">of your mesocycle</p>
             </CardContent>
           </Card>
@@ -82,7 +81,7 @@ export default async function DashboardPage() {
               <Activity className="h-4 w-4 text-muted-foreground" />
             </CardHeader>
             <CardContent>
-              <div className="text-2xl font-bold">{stats.totalWorkouts}</div>
+              <div className="text-2xl font-bold">{overview.totalWorkouts}</div>
               <p className="text-xs text-muted-foreground">this mesocycle</p>
             </CardContent>
           </Card>
@@ -95,7 +94,9 @@ export default async function DashboardPage() {
               <Target className="h-4 w-4 text-muted-foreground" />
             </CardHeader>
             <CardContent>
-              <div className="text-2xl font-bold">{stats.nextWorkout}</div>
+              <div className="text-2xl font-bold">
+                {overview.nextWorkout ?? 'None'}
+              </div>
               <p className="text-xs text-muted-foreground">scheduled today</p>
             </CardContent>
           </Card>
@@ -106,7 +107,9 @@ export default async function DashboardPage() {
               <TrendingUp className="h-4 w-4 text-muted-foreground" />
             </CardHeader>
             <CardContent>
-              <div className="text-2xl font-bold">{stats.personalRecords}</div>
+              <div className="text-2xl font-bold">
+                {overview.personalRecords}
+              </div>
               <p className="text-xs text-muted-foreground">this week</p>
             </CardContent>
           </Card>
@@ -121,18 +124,18 @@ export default async function DashboardPage() {
         </CardHeader>
         <CardContent>
           <div className="space-y-4">
-            {recentWorkouts.map((workout) => (
+            {overview.recentWorkouts.map((workout) => (
               <div
-                key={workout.id}
+                key={workout.workoutId}
                 className="flex items-center justify-between p-4 border rounded-lg hover:bg-accent/50 transition-colors"
               >
                 <div>
-                  <p className="font-medium">{workout.name}</p>
+                  <p className="font-medium">{workout.workoutLabel}</p>
                   <p className="text-sm text-muted-foreground">
-                    {workout.date} • {workout.sets} sets completed
+                    {workout.workoutDate} • {workout.setCount} sets completed
                   </p>
                 </div>
-                <Link href={`/logger/${workout.id}`}>
+                <Link href={`/logger/${workout.workoutId}`}>
                   <Button variant="ghost" size="icon">
                     <ArrowRight className="h-4 w-4" />
                   </Button>

--- a/src/db/queries/dashboard.ts
+++ b/src/db/queries/dashboard.ts
@@ -1,0 +1,73 @@
+import { db } from '../index';
+import { mesocycles, workouts } from '../schema';
+import {
+  getRecentWorkouts,
+  getWorkoutCompletionRate,
+  getPersonalRecords,
+} from './stats';
+import { eq, desc, and, gte } from 'drizzle-orm';
+import { differenceInDays, startOfDay } from 'date-fns';
+import { parseLocalDate } from '@/lib/utils/date';
+
+export interface DashboardOverview {
+  currentWeek: number | null;
+  totalWorkouts: number;
+  nextWorkout?: string;
+  personalRecords: number;
+  recentWorkouts: Awaited<ReturnType<typeof getRecentWorkouts>>;
+}
+
+export async function getDashboardOverview(
+  userId: string,
+): Promise<DashboardOverview> {
+  const [mesocycle] = await db
+    .select({
+      id: mesocycles.id,
+      startDate: mesocycles.startDate,
+      weeks: mesocycles.weeks,
+    })
+    .from(mesocycles)
+    .where(eq(mesocycles.userId, userId))
+    .orderBy(desc(mesocycles.startDate))
+    .limit(1);
+
+  let currentWeek: number | null = null;
+  let nextWorkoutLabel: string | undefined;
+
+  if (mesocycle) {
+    const startDate = parseLocalDate(String(mesocycle.startDate));
+    const daysElapsed = differenceInDays(startOfDay(new Date()), startDate);
+    currentWeek = Math.floor(daysElapsed / 7) + 1;
+
+    const today = startOfDay(new Date()).toISOString().split('T')[0];
+    const [nextWorkout] = await db
+      .select({ label: workouts.label })
+      .from(workouts)
+      .where(
+        and(
+          eq(workouts.mesocycleId, mesocycle.id),
+          gte(workouts.scheduledFor, today),
+        ),
+      )
+      .orderBy(workouts.scheduledFor)
+      .limit(1);
+
+    if (nextWorkout) {
+      nextWorkoutLabel = nextWorkout.label ?? undefined;
+    }
+  }
+
+  const [recentWorkouts, completion, personalRecords] = await Promise.all([
+    getRecentWorkouts(userId, 3),
+    getWorkoutCompletionRate(userId),
+    getPersonalRecords(userId),
+  ]);
+
+  return {
+    currentWeek,
+    totalWorkouts: completion.totalWorkouts,
+    nextWorkout: nextWorkoutLabel,
+    personalRecords: personalRecords.length,
+    recentWorkouts,
+  };
+}

--- a/tests/dashboard.test.ts
+++ b/tests/dashboard.test.ts
@@ -1,0 +1,85 @@
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  afterEach,
+  type Mock,
+} from 'vitest';
+import { getDashboardOverview } from '@/db/queries/dashboard';
+import {
+  getRecentWorkouts,
+  getWorkoutCompletionRate,
+  getPersonalRecords,
+} from '@/db/queries/stats';
+
+vi.mock('@/db/queries/stats');
+const selectMock: Mock = vi.fn();
+vi.mock('@/db/index', () => ({
+  db: { select: selectMock },
+  mesocycles: {},
+  workouts: {},
+}));
+
+type QueryResult = Record<string, unknown>[];
+function createSelect(result: QueryResult) {
+  return () => ({
+    from: () => ({
+      where: () => ({
+        orderBy: () => ({
+          limit: () => Promise.resolve(result),
+        }),
+      }),
+    }),
+  });
+}
+
+describe('getDashboardOverview', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('aggregates dashboard data', async () => {
+    vi.setSystemTime(new Date('2024-01-10'));
+    selectMock.mockImplementationOnce(
+      createSelect([{ id: 'm1', startDate: '2024-01-01', weeks: 4 }]),
+    );
+    selectMock.mockImplementationOnce(createSelect([{ label: 'Push Day' }]));
+
+    (getRecentWorkouts as Mock).mockResolvedValue([{ workoutId: 'w1' }]);
+    (getWorkoutCompletionRate as Mock).mockResolvedValue({
+      totalWorkouts: 5,
+    });
+    (getPersonalRecords as Mock).mockResolvedValue([{ id: 1 }, { id: 2 }]);
+
+    const result = await getDashboardOverview('user1');
+
+    expect(result).toEqual({
+      currentWeek: 2,
+      totalWorkouts: 5,
+      nextWorkout: 'Push Day',
+      personalRecords: 2,
+      recentWorkouts: [{ workoutId: 'w1' }],
+    });
+  });
+
+  it('handles missing mesocycle', async () => {
+    selectMock.mockImplementationOnce(createSelect([]));
+
+    (getRecentWorkouts as Mock).mockResolvedValue([]);
+    (getWorkoutCompletionRate as Mock).mockResolvedValue({
+      totalWorkouts: 0,
+    });
+    (getPersonalRecords as Mock).mockResolvedValue([]);
+
+    const result = await getDashboardOverview('user1');
+
+    expect(result.currentWeek).toBeNull();
+    expect(result.nextWorkout).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- add `getDashboardOverview` query to compose dashboard data
- integrate new query into dashboard page
- show real stats and recent workouts
- test dashboard overview query logic

## Testing
- `pnpm lint --fix --max-warnings 0`
- `pnpm format`
- `pnpm test:ci`
- `pnpm run build` *(fails: Failed to fetch `Geist` font)*
- `pnpm exec tsc --noEmit --strict`


------
https://chatgpt.com/codex/tasks/task_b_683f8ed3e2ac8323a27288a1f41c38dc