### PR TITLE
fix: restrict debug env endpoint

### DIFF
--- a/src/app/api/debug-env/route.ts
+++ b/src/app/api/debug-env/route.ts
@@ -1,6 +1,10 @@
 import { NextResponse } from 'next/server';
 
 export async function GET() {
+  if (process.env.NODE_ENV !== 'development') {
+    return new Response('Not Found', { status: 404 });
+  }
+
   console.log('🔍 [Debug API] Environment check requested');
 
   const envInfo = {


### PR DESCRIPTION
## Summary
- guard debug-env endpoint so it's only available during development

## Testing
- `pnpm lint --fix --max-warnings 0`
- `pnpm format`
- `pnpm test:ci`
- `pnpm run build`
- `pnpm exec tsc --noEmit --strict`


------
https://chatgpt.com/codex/tasks/task_b_683fc7b2444c83238d69097b23467175