### PR TITLE
fix: correct logger export and remove duplicate import

### DIFF
--- a/src/app/stats/page.tsx
+++ b/src/app/stats/page.tsx
@@ -11,7 +11,6 @@ import {
 } from '@/lib/utils/stats-utils';
 import type { RawPersonalRecord, RawMuscleGroup } from '@/lib/types/stats';
 import { StatsPageClient } from './StatsPageClient';
-import { logger } from '@/lib/logger';
 
 export default async function StatsPage() {
   const supabase = await createClient();
@@ -21,7 +20,6 @@ export default async function StatsPage() {
 
   if (!user) {
     redirect('/');
-
   }
 
   logger.info(`[StatsPage] Loading stats for user ${user.id}`);

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,5 +1,6 @@
 export const logger = {
-  info: (...args: unknown[]) => console.log(...args),
+  log: (...args: unknown[]) => console.log(...args),
+  info: (...args: unknown[]) => console.info(...args),
   warn: (...args: unknown[]) => console.warn(...args),
   error: (...args: unknown[]) => console.error(...args),
   debug: (...args: unknown[]) => {
@@ -8,4 +9,5 @@ export const logger = {
     }
   },
 };
-er;
+
+export default logger;


### PR DESCRIPTION
## Summary
- add `log` method and default export to logger
- remove duplicate `logger` import on Stats page

## Testing
- `pnpm lint --fix --max-warnings 0`
- `pnpm format`
- `pnpm test:ci`
- `pnpm run build`
- `pnpm exec tsc --noEmit --strict`


------
https://chatgpt.com/codex/tasks/task_b_68406b331734832385a5f62273173869