### PR TITLE
feature/stats-filter

### DIFF
--- a/src/app/stats/StatsPageClient.tsx
+++ b/src/app/stats/StatsPageClient.tsx
@@ -6,9 +6,12 @@ import { ProgressChart } from '@/components/stats/ProgressChart';
 import { MuscleGroupChart } from '@/components/stats/MuscleGroupChart';
 import { OneRMCalculator } from '@/components/stats/OneRMCalculator';
 import { ExerciseStats } from '@/components/stats/ExerciseStats';
+import { StatsFilters } from '@/components/stats/StatsFilters';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Activity, TrendingUp, Trophy, Target } from 'lucide-react';
-import { format } from 'date-fns';
+import { format, startOfDay, endOfDay } from 'date-fns';
+import { useState, useMemo } from 'react';
+import type { DateRange } from 'react-day-picker';
 import { useUserPreferences } from '@/lib/contexts/UserPreferencesContext';
 import type {
   RecentWorkout,
@@ -41,6 +44,54 @@ export function StatsPageClient({
   avgSetsPerWorkout,
 }: StatsPageClientProps) {
   const { weightUnit, convertWeight } = useUserPreferences();
+  const [dateRange, setDateRange] = useState<DateRange | undefined>();
+  const [selectedExercise, setSelectedExercise] = useState<
+    string | undefined
+  >();
+  const [selectedMuscle, setSelectedMuscle] = useState<string | undefined>();
+
+  const muscleGroups = useMemo(
+    () => Array.from(new Set(muscleDistribution.map((m) => m.primaryMuscle))),
+    [muscleDistribution],
+  );
+
+  const filteredRecentWorkouts = useMemo(() => {
+    return recentWorkouts.filter((w) => {
+      const date = new Date(w.workoutDate);
+      if (dateRange?.from && date < startOfDay(dateRange.from)) return false;
+      if (dateRange?.to && date > endOfDay(dateRange.to)) return false;
+      return true;
+    });
+  }, [recentWorkouts, dateRange]);
+
+  const filteredVolumeData = useMemo(() => {
+    return volumeData.filter((d) => {
+      const date = new Date(d.date);
+      if (dateRange?.from && date < startOfDay(dateRange.from)) return false;
+      if (dateRange?.to && date > endOfDay(dateRange.to)) return false;
+      return true;
+    });
+  }, [volumeData, dateRange]);
+
+  const filteredMuscleDistribution = useMemo(() => {
+    return muscleDistribution.filter((m) =>
+      selectedMuscle ? m.primaryMuscle === selectedMuscle : true,
+    );
+  }, [muscleDistribution, selectedMuscle]);
+
+  const filteredPersonalRecords = useMemo(() => {
+    let prs = personalRecords;
+    if (selectedExercise) {
+      prs = prs.filter((pr) => pr.exerciseId === selectedExercise);
+    }
+    if (selectedMuscle) {
+      const ids = userExercises
+        .filter((ex) => ex.primaryMuscle === selectedMuscle)
+        .map((ex) => ex.id);
+      prs = prs.filter((pr) => ids.includes(pr.exerciseId));
+    }
+    return prs;
+  }, [personalRecords, selectedExercise, selectedMuscle, userExercises]);
 
   return (
     <div className="container mx-auto px-4 py-8 space-y-8">
@@ -50,6 +101,14 @@ export function StatsPageClient({
           Track your progress and analyze your training patterns
         </p>
       </div>
+
+      <StatsFilters
+        onDateRangeChange={setDateRange}
+        onExerciseChange={setSelectedExercise}
+        onMuscleGroupChange={setSelectedMuscle}
+        exercises={userExercises.map((ex) => ({ id: ex.id, name: ex.name }))}
+        muscleGroups={muscleGroups}
+      />
 
       <Tabs defaultValue="overview" className="space-y-4">
         <TabsList className="grid w-full grid-cols-4 lg:w-[500px]">
@@ -92,7 +151,7 @@ export function StatsPageClient({
           <div>
             <h2 className="text-2xl font-bold mb-4">Personal Records</h2>
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-              {personalRecords.slice(0, 6).map((pr) => (
+              {filteredPersonalRecords.slice(0, 6).map((pr) => (
                 <PRCard
                   key={pr.exerciseId}
                   exerciseName={pr.exerciseName}
@@ -108,7 +167,7 @@ export function StatsPageClient({
           <div>
             <h2 className="text-2xl font-bold mb-4">Recent Workouts</h2>
             <div className="space-y-3">
-              {recentWorkouts.map((workout) => (
+              {filteredRecentWorkouts.map((workout) => (
                 <div
                   key={workout.workoutId}
                   className="p-4 border rounded-lg hover:bg-accent/50 transition-colors"
@@ -161,7 +220,7 @@ export function StatsPageClient({
             <ProgressChart
               title="Volume Progress"
               description="Total training volume over time"
-              data={volumeData.map((d) => ({
+              data={filteredVolumeData.map((d) => ({
                 date: d.date,
                 volume: Number(d.totalVolume) || 0,
               }))}
@@ -174,7 +233,7 @@ export function StatsPageClient({
             />
 
             <MuscleGroupChart
-              data={muscleDistribution}
+              data={filteredMuscleDistribution}
               title="Training Focus"
               description="Volume distribution by muscle group"
               dataKey="totalVolume"
@@ -185,7 +244,7 @@ export function StatsPageClient({
           <ProgressChart
             title="Training Frequency"
             description="Number of sets performed over time"
-            data={volumeData.map((d) => ({
+            data={filteredVolumeData.map((d) => ({
               date: d.date,
               sets: Number(d.totalSets) || 0,
             }))}

--- a/src/lib/utils/stats-filter.ts
+++ b/src/lib/utils/stats-filter.ts
@@ -1,0 +1,45 @@
+import { startOfDay, endOfDay } from 'date-fns';
+import type { DateRange } from 'react-day-picker';
+import type { PersonalRecord, UserExercise } from '@/lib/types/stats';
+
+export function isDateInRange(date: Date | string, range?: DateRange): boolean {
+  if (!range) return true;
+  const parsed = new Date(date);
+  if (range.from && parsed < startOfDay(range.from)) return false;
+  if (range.to && parsed > endOfDay(range.to)) return false;
+  return true;
+}
+
+export interface PersonalRecordFilterOpts {
+  range?: DateRange;
+  exerciseId?: string;
+  muscle?: string;
+  userExercises: UserExercise[];
+}
+
+export function filterPersonalRecords(
+  records: PersonalRecord[],
+  { range, exerciseId, muscle, userExercises }: PersonalRecordFilterOpts,
+): PersonalRecord[] {
+  let prs = records;
+  if (exerciseId) {
+    prs = prs.filter((pr) => pr.exerciseId === exerciseId);
+  }
+  if (muscle) {
+    const ids = userExercises
+      .filter((ex) => ex.primaryMuscle === muscle)
+      .map((ex) => ex.id);
+    prs = prs.filter((pr) => ids.includes(pr.exerciseId));
+  }
+  if (range) {
+    prs = prs.filter((pr) => {
+      const dates = [
+        pr.maxWeight?.date,
+        pr.maxVolume?.date,
+        pr.maxReps?.date,
+      ].filter(Boolean);
+      return dates.some((d) => isDateInRange(d as string | Date, range));
+    });
+  }
+  return prs;
+}

--- a/tests/stats-filter.test.ts
+++ b/tests/stats-filter.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { isDateInRange, filterPersonalRecords } from '@/lib/utils/stats-filter';
+
+const userExercises = [
+  { id: 'e1', name: 'Bench', type: null, primaryMuscle: 'Chest' },
+  { id: 'e2', name: 'Squat', type: null, primaryMuscle: 'Legs' },
+];
+
+const prs = [
+  {
+    exerciseId: 'e1',
+    exerciseName: 'Bench',
+    maxWeight: { weight: 100, reps: 1, date: '2024-05-01' },
+    maxVolume: null,
+    maxReps: null,
+  },
+  {
+    exerciseId: 'e2',
+    exerciseName: 'Squat',
+    maxWeight: { weight: 150, reps: 5, date: '2024-04-01' },
+    maxVolume: null,
+    maxReps: null,
+  },
+];
+
+describe('isDateInRange', () => {
+  it('checks date boundaries', () => {
+    const range = { from: new Date('2024-05-01'), to: new Date('2024-05-31') };
+    expect(isDateInRange('2024-05-10', range)).toBe(true);
+    expect(isDateInRange('2024-04-30', range)).toBe(false);
+  });
+});
+
+describe('filterPersonalRecords', () => {
+  it('filters by exercise and date', () => {
+    const range = { from: new Date('2024-05-01'), to: new Date('2024-05-31') };
+    const result = filterPersonalRecords(prs, {
+      range,
+      exerciseId: 'e1',
+      userExercises,
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0].exerciseId).toBe('e1');
+  });
+});


### PR DESCRIPTION
## Summary
- add `StatsFilters` UI to stats page
- filter stats data using selected date range, exercise, and muscle group
- update charts and PR list to use filtered data

## Testing
- `pnpm lint --fix --max-warnings 0`
- `pnpm format`
- `pnpm test:ci`
- `pnpm run build`
- `pnpm exec tsc --noEmit --strict`


------
https://chatgpt.com/codex/tasks/task_b_68406fe938788323a462b224910825d0