### PR TITLE
Add 1RM progress chart

### DIFF
--- a/src/components/stats/OneRMProgressChart.tsx
+++ b/src/components/stats/OneRMProgressChart.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import { useMemo } from 'react';
+import { ProgressChart } from './ProgressChart';
+import type { OneRMFormula } from '@/lib/utils/1rm-calculator';
+import { calculateAverage1RM, calculate1RM } from '@/lib/utils/1rm-calculator';
+import { useUserPreferences } from '@/lib/contexts/UserPreferencesContext';
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+} from '@/components/ui/card';
+import { format } from 'date-fns';
+
+interface SetData {
+  date: string | Date;
+  weight: number;
+  reps: number;
+}
+
+interface OneRMProgressChartProps {
+  exerciseName: string;
+  sets: SetData[];
+  formula?: OneRMFormula;
+}
+
+export function OneRMProgressChart({
+  exerciseName,
+  sets,
+  formula,
+}: OneRMProgressChartProps) {
+  const { weightUnit, convertWeight } = useUserPreferences();
+
+  const chartData = useMemo(() => {
+    const map = new Map<string, number>();
+    sets.forEach((set) => {
+      const date =
+        typeof set.date === 'string'
+          ? set.date.split('T')[0]
+          : format(set.date, 'yyyy-MM-dd');
+      const oneRm = formula
+        ? calculate1RM(set.weight, set.reps, formula)
+        : calculateAverage1RM(set.weight, set.reps);
+      const current = map.get(date);
+      if (!current || oneRm > current) {
+        map.set(date, oneRm);
+      }
+    });
+    return Array.from(map.entries())
+      .map(([date, oneRm]) => ({ date, oneRm: convertWeight(oneRm) }))
+      .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
+  }, [sets, formula, convertWeight]);
+
+  if (chartData.length === 0) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>{exerciseName} 1RM Progress</CardTitle>
+          <CardDescription>Not enough data to display</CardDescription>
+        </CardHeader>
+      </Card>
+    );
+  }
+
+  return (
+    <ProgressChart
+      title={`${exerciseName} 1RM Progress`}
+      description="Estimated one-rep max over time"
+      data={chartData}
+      dataKey="oneRm"
+      xAxisKey="date"
+      yAxisLabel={`1RM (${weightUnit})`}
+      chartType="line"
+      color="#ef4444"
+    />
+  );
+}

--- a/src/components/stats/index.ts
+++ b/src/components/stats/index.ts
@@ -6,3 +6,4 @@ export { StatsFilters } from './StatsFilters';
 export { ExerciseProgressChart } from './ExerciseProgressChart';
 export { OneRMCalculator } from './OneRMCalculator';
 export { ExerciseStats } from './ExerciseStats';
+export { OneRMProgressChart } from './OneRMProgressChart';


### PR DESCRIPTION
## Summary
- chart estimated 1RM over time with OneRMProgressChart
- expose OneRMProgressChart in stats page

## Testing
- `pnpm lint --fix --max-warnings 0`
- `pnpm format`
- `pnpm test:ci`
- `rm -rf .next && pnpm run build`
- `pnpm exec tsc --noEmit --strict`


------
https://chatgpt.com/codex/tasks/task_b_68407496e00c8323845508911b3f2e86