### PR TITLE
Add weekly adherence stats

### DIFF
--- a/src/app/stats/StatsPageClient.tsx
+++ b/src/app/stats/StatsPageClient.tsx
@@ -23,6 +23,7 @@ import type {
   MuscleGroup,
   CompletionRate,
   UserExercise,
+  WeeklyCompletion,
 } from '@/lib/types/stats';
 
 interface StatsPageClientProps {
@@ -32,6 +33,7 @@ interface StatsPageClientProps {
   muscleDistribution: MuscleGroup[];
   completionRate: CompletionRate;
   userExercises: UserExercise[];
+  weeklyCompletion: WeeklyCompletion[];
   totalVolume: number;
   avgSetsPerWorkout: number;
 }
@@ -52,6 +54,7 @@ export function StatsPageClient({
   muscleDistribution,
   completionRate,
   userExercises,
+  weeklyCompletion,
   totalVolume,
   avgSetsPerWorkout,
 }: StatsPageClientProps) {
@@ -78,6 +81,11 @@ export function StatsPageClient({
   const filteredVolumeData = useMemo(
     () => volumeData.filter((d) => isDateInRange(d.date, dateRange)),
     [volumeData, dateRange],
+  );
+
+  const filteredWeeklyCompletion = useMemo(
+    () => weeklyCompletion.filter((d) => isDateInRange(d.week, dateRange)),
+    [weeklyCompletion, dateRange],
   );
 
   const filteredMuscleDistribution = useMemo(() => {
@@ -265,6 +273,20 @@ export function StatsPageClient({
               dataKey="totalVolume"
             />
           </div>
+
+          <ProgressChart
+            title="Weekly Adherence"
+            description="Completion rate by week"
+            data={filteredWeeklyCompletion.map((d) => ({
+              date: d.week,
+              adherence: Number(d.completionRate) || 0,
+            }))}
+            dataKey="adherence"
+            xAxisKey="date"
+            yAxisLabel="Completion %"
+            chartType="line"
+            color="#10b981"
+          />
 
           {/* Sets & Intensity Trends */}
           <ProgressChart

--- a/src/app/stats/page.tsx
+++ b/src/app/stats/page.tsx
@@ -45,6 +45,7 @@ export default async function StatsPage() {
       muscleDistribution={muscleDistribution}
       completionRate={data.completionRate}
       userExercises={data.userExercises}
+      weeklyCompletion={data.weeklyCompletion}
       totalVolume={totalVolume}
       avgSetsPerWorkout={avgSetsPerWorkout}
     />

--- a/src/lib/api/stats.ts
+++ b/src/lib/api/stats.ts
@@ -4,6 +4,7 @@ import {
   getVolumeProgressData,
   getMuscleGroupDistribution,
   getWorkoutCompletionRate,
+  getWeeklyCompletionData,
   getUserExercises,
 } from '@/db/queries/stats';
 import { logger } from '@/lib/logger';
@@ -12,6 +13,7 @@ import type {
   RecentWorkout,
   UserExercise,
   VolumeData,
+  WeeklyCompletion,
 } from '@/lib/types/stats';
 
 export interface StatsData {
@@ -21,6 +23,7 @@ export interface StatsData {
   muscleDistribution: unknown[];
   completionRate: CompletionRate;
   userExercises: UserExercise[];
+  weeklyCompletion: WeeklyCompletion[];
 }
 
 export async function fetchStats(userId: string): Promise<StatsData> {
@@ -30,6 +33,7 @@ export async function fetchStats(userId: string): Promise<StatsData> {
     volumeData,
     muscleDistribution,
     completionRate,
+    weeklyCompletion,
     userExercises,
   ] = await Promise.allSettled([
     getRecentWorkouts(userId, 5),
@@ -37,6 +41,7 @@ export async function fetchStats(userId: string): Promise<StatsData> {
     getVolumeProgressData(userId),
     getMuscleGroupDistribution(userId),
     getWorkoutCompletionRate(userId),
+    getWeeklyCompletionData(userId),
     getUserExercises(userId),
   ]);
 
@@ -56,5 +61,6 @@ export async function fetchStats(userId: string): Promise<StatsData> {
       completionRate: 0,
     } as CompletionRate),
     userExercises: safe(userExercises, [] as UserExercise[]),
+    weeklyCompletion: safe(weeklyCompletion, [] as WeeklyCompletion[]),
   };
 }

--- a/src/lib/types/stats.ts
+++ b/src/lib/types/stats.ts
@@ -70,3 +70,10 @@ export interface RawPersonalRecord {
   maxVolume?: { volume: number; date: string | Date } | null;
   maxReps?: { reps: number; date: string | Date } | null;
 }
+
+export interface WeeklyCompletion {
+  week: string;
+  completedWorkouts: number;
+  totalWorkouts: number;
+  completionRate: number;
+}

--- a/tests/api-stats.test.ts
+++ b/tests/api-stats.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi, type Mock } from 'vitest';
+import { fetchStats } from '@/lib/api/stats';
+import {
+  getRecentWorkouts,
+  getPersonalRecords,
+  getVolumeProgressData,
+  getMuscleGroupDistribution,
+  getWorkoutCompletionRate,
+  getUserExercises,
+  getWeeklyCompletionData,
+} from '@/db/queries/stats';
+
+vi.mock('@/db/queries/stats');
+
+describe('fetchStats', () => {
+  it('returns aggregated stats data', async () => {
+    (getRecentWorkouts as Mock).mockResolvedValue([]);
+    (getPersonalRecords as Mock).mockResolvedValue([]);
+    (getVolumeProgressData as Mock).mockResolvedValue([]);
+    (getMuscleGroupDistribution as Mock).mockResolvedValue([]);
+    (getWorkoutCompletionRate as Mock).mockResolvedValue({
+      completedWorkouts: 5,
+      completionRate: 50,
+    });
+    (getUserExercises as Mock).mockResolvedValue([]);
+    (getWeeklyCompletionData as Mock).mockResolvedValue([
+      {
+        week: '2024-05-06',
+        completedWorkouts: 1,
+        totalWorkouts: 2,
+        completionRate: 50,
+      },
+    ]);
+
+    const result = await fetchStats('user1');
+
+    expect(result.weeklyCompletion).toHaveLength(1);
+    expect(getWeeklyCompletionData).toHaveBeenCalledWith('user1');
+  });
+});


### PR DESCRIPTION
## Summary
- track weekly completion rates with new DB query
- fetch weekly completion data in stats API
- visualize adherence trends in stats page
- support weekly adherence chart on client
- test stats API helpers

## Testing
- `pnpm lint --fix --max-warnings 0`
- `pnpm format`
- `pnpm test:ci`
- `pnpm run build`
- `pnpm exec tsc --noEmit --strict`


------
https://chatgpt.com/codex/tasks/task_b_68407c313d848323a79bd4b9e3e51110