### PR TITLE
feat: show upcoming workouts

### DIFF
--- a/src/app/api/debug-env/route.ts
+++ b/src/app/api/debug-env/route.ts
@@ -4,7 +4,6 @@ import { NextResponse } from 'next/server';
 export async function GET() {
   logger.log('🔍 [Debug API] Environment check requested');
 
-
   const envInfo = {
     timestamp: new Date().toISOString(),
     NODE_ENV: process.env.NODE_ENV,

--- a/src/app/logger/actions.ts
+++ b/src/app/logger/actions.ts
@@ -2,7 +2,7 @@
 
 import { createClient } from '@/lib/supabase/server';
 import { format } from 'date-fns';
-import { getWorkoutsInRange } from '@/db/queries/workouts';
+import { getWorkoutsInRange, getUpcomingWorkouts } from '@/db/queries/workouts';
 import { startOfWeek, endOfWeek } from 'date-fns';
 import { redirect } from 'next/navigation';
 
@@ -20,6 +20,19 @@ export async function getWorkoutsForCurrentWeek() {
   const end = endOfWeek(new Date(), { weekStartsOn: 1 });
 
   return getWorkoutsInRange(user.id, start, end);
+}
+
+export async function getAllUpcomingWorkouts() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    throw new Error('User not authenticated');
+  }
+
+  return getUpcomingWorkouts(user.id);
 }
 
 export async function createFreestyleWorkout() {

--- a/src/app/logger/upcoming/page.tsx
+++ b/src/app/logger/upcoming/page.tsx
@@ -9,18 +9,18 @@ import {
 import { Button } from '@/components/ui/button';
 import { format } from 'date-fns';
 import { parseLocalDate } from '@/lib/utils/date';
-import { getWorkoutsForCurrentWeek, createFreestyleWorkout } from './actions';
+import { getAllUpcomingWorkouts } from '../actions';
 
-export default async function LoggerPage() {
-  const workouts = await getWorkoutsForCurrentWeek();
+export default async function UpcomingWorkoutsPage() {
+  const workouts = await getAllUpcomingWorkouts();
 
   return (
     <div className="container mx-auto px-4 py-8 space-y-8">
       <div>
-        <h1 className="text-3xl font-bold mb-4">Workout Logger</h1>
+        <h1 className="text-3xl font-bold mb-4">Upcoming Workouts</h1>
         {workouts.length === 0 ? (
           <p className="text-muted-foreground">
-            No workouts scheduled for this week.
+            No upcoming workouts scheduled.
           </p>
         ) : (
           <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
@@ -45,24 +45,11 @@ export default async function LoggerPage() {
           </div>
         )}
       </div>
-
-      <div className="space-y-4">
-        <form action={createFreestyleWorkout}>
-          <Button type="submit" className="w-full">
-            Start Freestyle Workout
-          </Button>
-        </form>
-        <Link href="/logger/upcoming" className="block">
-          <Button variant="outline" className="w-full">
-            View Upcoming Workouts
-          </Button>
-        </Link>
-        <Link href="/stats" className="block">
-          <Button variant="outline" className="w-full">
-            View History
-          </Button>
-        </Link>
-      </div>
+      <Link href="/logger" className="block">
+        <Button variant="outline" className="w-full">
+          Back to This Week
+        </Button>
+      </Link>
     </div>
   );
 }

--- a/src/db/queries/workouts.ts
+++ b/src/db/queries/workouts.ts
@@ -29,3 +29,23 @@ export async function getWorkoutsInRange(
     )
     .orderBy(workouts.scheduledFor);
 }
+
+export async function getUpcomingWorkouts(userId: string, limit = 50) {
+  const today = new Date().toISOString().split('T')[0];
+
+  return db
+    .select({
+      id: workouts.id,
+      scheduledFor: workouts.scheduledFor,
+      label: workouts.label,
+      weekNumber: workouts.weekNumber,
+      intensityModifier: workouts.intensityModifier,
+    })
+    .from(workouts)
+    .innerJoin(mesocycles, eq(workouts.mesocycleId, mesocycles.id))
+    .where(
+      and(eq(mesocycles.userId, userId), gte(workouts.scheduledFor, today)),
+    )
+    .orderBy(workouts.scheduledFor)
+    .limit(limit);
+}

--- a/tests/workouts.test.ts
+++ b/tests/workouts.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import { getUpcomingWorkouts } from '@/db/queries/workouts';
+
+// eslint-disable-next-line no-var
+var selectMock: Mock;
+vi.mock('@/db/index', () => {
+  selectMock = vi.fn();
+  return {
+    db: { select: selectMock },
+    workouts: {},
+    mesocycles: {},
+  };
+});
+
+type QueryResult = Record<string, unknown>[];
+function createSelect(result: QueryResult) {
+  return () => ({
+    from: () => ({
+      innerJoin: () => ({
+        where: () => ({
+          orderBy: () => ({
+            limit: () => Promise.resolve(result),
+          }),
+        }),
+      }),
+    }),
+  });
+}
+
+describe('getUpcomingWorkouts', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns workouts scheduled from today onward', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2024-05-10'));
+    selectMock.mockImplementationOnce(createSelect([{ id: 'w1' }]));
+
+    const result = await getUpcomingWorkouts('user1');
+
+    expect(result).toEqual([{ id: 'w1' }]);
+    expect(selectMock).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- provide a list of upcoming workouts
- add a server action and DB query to fetch them
- add a test for getUpcomingWorkouts

## Testing
- `pnpm lint --fix --max-warnings 0`
- `pnpm format`
- `pnpm test:ci`
- `pnpm run build`
- `pnpm exec tsc --noEmit --strict`


------
https://chatgpt.com/codex/tasks/task_b_68431676e8a083239d6da25f344507df