### PR TITLE
Enable editing workout structures in mesocycle

### DIFF
--- a/src/lib/utils/workout-template-utils.ts
+++ b/src/lib/utils/workout-template-utils.ts
@@ -1,0 +1,62 @@
+import { parseLocalDate } from '@/lib/utils/date';
+import { WorkoutTemplate } from '@/components/mesocycles/workout-template-designer';
+
+interface WorkoutExercise {
+  exercise_id: string;
+  order_idx: number;
+  defaults: {
+    sets: number;
+    reps: string;
+    rir?: number;
+    rpe?: number;
+    rest: string;
+  };
+  exercise?: { name: string } | null;
+}
+
+interface Workout {
+  id: string;
+  scheduled_for: string;
+  label: string;
+  week_number?: number;
+  workout_exercises?: WorkoutExercise[] | null;
+}
+
+/**
+ * Convert a list of workouts with exercises into workout templates.
+ * Workouts sharing the same base label are aggregated into one template
+ * with all associated days of the week.
+ */
+export function workoutsToTemplates(workouts: Workout[]): WorkoutTemplate[] {
+  const templateMap = new Map<string, WorkoutTemplate>();
+
+  workouts.forEach((w) => {
+    const baseLabel = w.label.replace(/ - Week \d+$/, '');
+    const day = parseLocalDate(w.scheduled_for).getDay();
+
+    if (!templateMap.has(baseLabel)) {
+      templateMap.set(baseLabel, {
+        id: crypto.randomUUID(),
+        label: baseLabel,
+        dayOfWeek: [day],
+        exercises:
+          (w.workout_exercises || [])
+            .sort((a, b) => a.order_idx - b.order_idx)
+            .map((ex) => ({
+              exerciseId: ex.exercise_id,
+              exerciseName: ex.exercise?.name,
+              orderIdx: ex.order_idx,
+              defaults: ex.defaults,
+            })) || [],
+      });
+    } else {
+      const existing = templateMap.get(baseLabel)!;
+      if (!existing.dayOfWeek.includes(day)) {
+        existing.dayOfWeek.push(day);
+        existing.dayOfWeek.sort();
+      }
+    }
+  });
+
+  return Array.from(templateMap.values());
+}

--- a/tests/workout-template-utils.test.ts
+++ b/tests/workout-template-utils.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { workoutsToTemplates } from '@/lib/utils/workout-template-utils';
+
+const workouts = [
+  {
+    id: 'w1',
+    scheduled_for: '2024-06-03',
+    label: 'Push - Week 1',
+    week_number: 1,
+    workout_exercises: [
+      {
+        exercise_id: 'e1',
+        order_idx: 0,
+        defaults: { sets: 3, reps: '8-12', rest: '2:00' },
+        exercise: { name: 'Bench' },
+      },
+    ],
+  },
+  {
+    id: 'w2',
+    scheduled_for: '2024-06-05',
+    label: 'Pull - Week 1',
+    week_number: 1,
+    workout_exercises: [
+      {
+        exercise_id: 'e2',
+        order_idx: 0,
+        defaults: { sets: 4, reps: '10', rest: '2:00' },
+        exercise: { name: 'Row' },
+      },
+    ],
+  },
+  {
+    id: 'w3',
+    scheduled_for: '2024-06-10',
+    label: 'Push - Week 2',
+    week_number: 2,
+    workout_exercises: [
+      {
+        exercise_id: 'e1',
+        order_idx: 0,
+        defaults: { sets: 3, reps: '8-12', rest: '2:00' },
+        exercise: { name: 'Bench' },
+      },
+    ],
+  },
+];
+
+describe('workoutsToTemplates', () => {
+  it('converts workouts to templates grouped by label', () => {
+    const templates = workoutsToTemplates(workouts);
+    expect(templates).toHaveLength(2);
+    const push = templates.find((t) => t.label === 'Push');
+    const pull = templates.find((t) => t.label === 'Pull');
+    expect(push?.dayOfWeek).toEqual([1]);
+    expect(pull?.dayOfWeek).toEqual([3]);
+    expect(push?.exercises[0].exerciseId).toBe('e1');
+  });
+});


### PR DESCRIPTION
## Summary
- allow MesocycleEditWizard to load workouts with exercises
- convert existing workouts to editable templates via `workoutsToTemplates`
- new utility `workout-template-utils` for workout conversions
- unit tests for the new conversion logic
- update note in edit wizard about overwriting workouts

## Testing
- `pnpm lint --fix --max-warnings 0`
- `pnpm format`
- `pnpm test:ci`
- `pnpm exec tsc --noEmit --strict`
- `pnpm run build`


------
https://chatgpt.com/codex/tasks/task_b_684378fd0c7c8323935da87a91835db1