### PR TITLE
feat: add smoothing line to exercise charts

### DIFF
--- a/src/components/stats/__tests__/MuscleGroupTimeFilter.test.tsx
+++ b/src/components/stats/__tests__/MuscleGroupTimeFilter.test.tsx
@@ -98,12 +98,10 @@ const createProps = () => {
 
 describe('StatsPageClient - Muscle Group Time Filter', () => {
   it('fetches updated muscle distribution when date range changes', async () => {
-    const fetchMock = vi
-      .spyOn(global, 'fetch')
-      .mockResolvedValue({
-        json: () => Promise.resolve({ data: [] }),
-        ok: true,
-      } as Response);
+    const fetchMock = vi.spyOn(global, 'fetch').mockResolvedValue({
+      json: () => Promise.resolve({ data: [] }),
+      ok: true,
+    } as Response);
 
     render(<StatsPageClient {...createProps()} />);
 


### PR DESCRIPTION
## Summary
- allow toggling a simple moving average line on ExerciseProgressChart
- adjust muscle group test formatting

## Testing
- `pnpm lint --fix --max-warnings 0`
- `pnpm format`
- `pnpm test:ci`
- `NEXT_PUBLIC_SUPABASE_URL=https://example.com NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy pnpm run build`
- `pnpm exec tsc --noEmit --strict`


------
https://chatgpt.com/codex/tasks/task_b_68506c3e2fb48327b2b81667ba6907f2