### PR TITLE
feat: configurable rest timer alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A modern, mobile-first web application for weightlifters to design mesocycles, l
 
 - **Mesocycle Builder**: Design custom training programs with periodization
 - **Exercise Catalogue**: Comprehensive exercise database with filtering
-- **In-Gym Logger**: Mobile-optimized interface with rest timer
+- **In-Gym Logger**: Mobile-optimized interface with rest timer and configurable notifications
 - **Progress Tracking**: Visualize 1RM estimates, volume load, and personal records
 - **Data Export**: Download your complete workout history as a CSV file
 - **AI Assistant**: Get help building mesocycles with AI (coming soon)

--- a/src/lib/stores/user-preferences.ts
+++ b/src/lib/stores/user-preferences.ts
@@ -1,0 +1,22 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+export type RestTimerNotification = 'sound' | 'vibrate' | 'both' | 'none';
+
+interface UserPreferencesState {
+  restTimerNotification: RestTimerNotification;
+  setRestTimerNotification: (value: RestTimerNotification) => void;
+}
+
+export const useUserPreferences = create<UserPreferencesState>()(
+  persist(
+    (set) => ({
+      restTimerNotification: 'sound',
+      setRestTimerNotification: (value) =>
+        set({ restTimerNotification: value }),
+    }),
+    {
+      name: 'user-preferences',
+    },
+  ),
+);

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -11,6 +11,9 @@ class ResizeObserver {
 }
 global.ResizeObserver = ResizeObserver;
 
+// jsdom doesn't implement scrollIntoView
+Element.prototype.scrollIntoView = vi.fn();
+
 // Extend Vitest's expect method with methods from react-testing-library
 expect.extend(matchers);
 

--- a/tests/rest-timer.test.tsx
+++ b/tests/rest-timer.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { RestTimer } from '@/components/logger/rest-timer';
+import { useUserPreferences } from '@/lib/stores/user-preferences';
+import { describe, it, expect, afterEach } from 'vitest';
+
+describe('RestTimer Notification', () => {
+  afterEach(() => {
+    useUserPreferences.getState().setRestTimerNotification('sound');
+  });
+
+  it('updates preference when selecting option', async () => {
+    render(<RestTimer />);
+    const trigger = screen.getByLabelText('Notification');
+    fireEvent.click(trigger);
+    const noneOption = await screen.findByText('None');
+    fireEvent.click(noneOption);
+
+    expect(useUserPreferences.getState().restTimerNotification).toBe('none');
+  });
+});


### PR DESCRIPTION
## Summary
- add Zustand store for user preferences
- let users pick sound or vibration notification for rest timer
- update readme
- test notification preference UI

## Testing
- `pnpm format`
- `pnpm lint --fix --max-warnings 0`
- `pnpm test:ci`
- `rm -rf .next && pnpm run build`
- `pnpm exec tsc --noEmit --strict`


------
https://chatgpt.com/codex/tasks/task_b_6851e4bfba688327b7161930f395c321